### PR TITLE
[BREAD-2162] Fix EventBus and Hilt conflicts

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,11 +14,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 11
+      - name: Setup Java 17
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
           distribution: 'temurin'
+          java-version: '17'
           cache: gradle
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/EventBus/build.gradle
+++ b/EventBus/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java'
+apply plugin: 'maven-publish'
 
 group = rootProject.group
 version = rootProject.version
@@ -31,20 +32,29 @@ task sourcesJar(type: Jar) {
     from sourceSets.main.allSource
 }
 
-apply from: rootProject.file("gradle/publish.gradle")
 // Set project-specific properties
 afterEvaluate {
-    publishing.publications {
-        mavenJava(MavenPublication) {
-            artifactId = "eventbus-java"
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                artifactId = "eventbus-java"
 
-            from components.java
-            artifact javadocJar
-            artifact sourcesJar
-            pom {
-                name = "EventBus"
-                description = "EventBus is a publish/subscribe event bus."
-                packaging = "jar"
+                from components.java
+                artifact javadocJar
+                artifact sourcesJar
+                pom {
+                    name = "EventBus"
+                    description = "EventBus is a publish/subscribe event bus."
+                    packaging = "jar"
+                }
+            }
+        }
+
+        repositories {
+            maven {
+                name = "GitHubPackages"
+                url = project.uri("https://maven.pkg.github.com/favordelivery/EventBus")
+                credentials(PasswordCredentials)
             }
         }
     }

--- a/EventBusAnnotationProcessor/build.gradle
+++ b/EventBusAnnotationProcessor/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java'
+apply plugin: 'maven-publish'
 
 group = rootProject.group
 version = rootProject.version
@@ -11,7 +12,7 @@ dependencies {
     implementation 'de.greenrobot:java-common:2.3.1'
 
     // Generates the required META-INF descriptor to make the processor incremental.
-    def incap = '0.2'
+    def incap = '1.0.0'
     compileOnly "net.ltgt.gradle.incap:incap:$incap"
     annotationProcessor "net.ltgt.gradle.incap:incap-processor:$incap"
 }
@@ -42,20 +43,29 @@ task sourcesJar(type: Jar) {
     from sourceSets.main.allSource
 }
 
-apply from: rootProject.file("gradle/publish.gradle")
 // Set project-specific properties
 afterEvaluate {
-    publishing.publications {
-        mavenJava(MavenPublication) {
-            artifactId = "eventbus-annotation-processor"
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                artifactId = "eventbus-annotation-processor"
 
-            from components.java
-            artifact javadocJar
-            artifact sourcesJar
-            pom {
-                name = "EventBus Annotation Processor"
-                description = "Precompiler for EventBus Annotations."
-                packaging = "jar"
+                from components.java
+                artifact javadocJar
+                artifact sourcesJar
+                pom {
+                    name = "EventBus Annotation Processor"
+                    description = "Precompiler for EventBus Annotations."
+                    packaging = "jar"
+                }
+            }
+        }
+
+        repositories {
+            maven {
+                name = "GitHubPackages"
+                url = project.uri("https://maven.pkg.github.com/favordelivery/EventBus")
+                credentials(PasswordCredentials)
             }
         }
     }

--- a/EventBusAnnotationProcessor/src/org/greenrobot/eventbus/annotationprocessor/EventBusAnnotationProcessor.java
+++ b/EventBusAnnotationProcessor/src/org/greenrobot/eventbus/annotationprocessor/EventBusAnnotationProcessor.java
@@ -81,8 +81,8 @@ public class EventBusAnnotationProcessor extends AbstractProcessor {
         try {
             String index = processingEnv.getOptions().get(OPTION_EVENT_BUS_INDEX);
             if (index == null) {
-                messager.printMessage(Diagnostic.Kind.ERROR, "No option " + OPTION_EVENT_BUS_INDEX +
-                        " passed to annotation processor");
+//                messager.printMessage(Diagnostic.Kind.ERROR, "No option " + OPTION_EVENT_BUS_INDEX +
+//                        " passed to annotation processor");
                 return false;
             }
             verbose = Boolean.parseBoolean(processingEnv.getOptions().get(OPTION_VERBOSE));

--- a/EventBusPerformance/AndroidManifest.xml
+++ b/EventBusPerformance/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.greenrobot.eventbusperf">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-feature
         android:name="android.hardware.touchscreen"
@@ -11,7 +10,8 @@
         android:label="@string/app_name" >
         <activity
             android:name="org.greenrobot.eventbusperf.TestSetupActivity"
-            android:label="@string/app_name" >
+            android:label="@string/app_name"
+            android:exported="true" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/EventBusPerformance/build.gradle
+++ b/EventBusPerformance/build.gradle
@@ -5,8 +5,7 @@ buildscript {
     }
 
     dependencies {
-        // Note: IntelliJ IDEA 2021.1 only supports up to version 4.1
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:8.0.2'
     }
 }
 
@@ -19,7 +18,8 @@ dependencies {
 }
 
 android {
-    compileSdkVersion _compileSdkVersion
+    namespace "org.greenrobot.eventbusperf"
+    compileSdkVersion = _compileSdkVersion
 
     sourceSets {
         main {
@@ -31,7 +31,7 @@ android {
 
     defaultConfig {
         minSdkVersion 7
-        targetSdkVersion 26
+        targetSdkVersion 34
         versionCode 1
         versionName "2.0.0"
         javaCompileOptions {

--- a/EventBusTest/AndroidManifest.xml
+++ b/EventBusTest/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="org.greenrobot.eventbus">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 

--- a/EventBusTest/build.gradle
+++ b/EventBusTest/build.gradle
@@ -5,8 +5,7 @@ buildscript {
     }
 
     dependencies {
-        // Note: IntelliJ IDEA 2021.1 only supports up to version 4.1
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:8.0.2'
     }
 }
 
@@ -24,7 +23,8 @@ dependencies {
 }
 
 android {
-    compileSdkVersion _compileSdkVersion
+    namespace "org.greenrobot.eventbus"
+    compileSdkVersion = _compileSdkVersion
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_7
@@ -43,7 +43,7 @@ android {
 
     defaultConfig {
         minSdkVersion 9
-        targetSdkVersion 26
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ EventBus...
  * is proven in practice by apps with 1,000,000,000+ installs
  * has advanced features like delivery threads, subscriber priorities, etc.
 
+Favor modifications
+-------------------
+1. `eventbus-annnotation-processor` was modified to not conflict with `hilt. `eventbus-annnotation-processor`-only 
+is published to the repositories packages maven repo. Consuming applications should be updated to add this repo's
+packages and update version for `eventbus-annnotation-processor` artifact. Publishing is manual.
+
 EventBus in 3 steps
 -------------------
 1. Define events:

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 
 // Set group and version in root build.gradle so publish-plugin can detect them.
 group = "org.greenrobot"
-version = "3.3.2"
+version = "3.3.1-favor-1"
 
 allprojects {
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -6,14 +6,11 @@ buildscript {
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
     }
-    dependencies {
-        classpath "io.github.gradle-nexus:publish-plugin:1.1.0"
-    }
 }
 
 // Set group and version in root build.gradle so publish-plugin can detect them.
 group = "org.greenrobot"
-version = "3.3.1"
+version = "3.3.2"
 
 allprojects {
     repositories {
@@ -32,21 +29,4 @@ if (JavaVersion.current().isJava8Compatible()) {
 
 wrapper {
     distributionType = Wrapper.DistributionType.ALL
-}
-
-// Plugin to publish to Central https://github.com/gradle-nexus/publish-plugin/
-// This plugin ensures a separate, named staging repo is created for each build when publishing.
-apply plugin: "io.github.gradle-nexus.publish-plugin"
-nexusPublishing {
-    repositories {
-        sonatype {
-            if (project.hasProperty("sonatypeUsername") && project.hasProperty("sonatypePassword")) {
-                println('nexusPublishing credentials supplied.')
-                username = sonatypeUsername
-                password = sonatypePassword
-            } else {
-                println('nexusPublishing credentials NOT supplied.')
-            }
-        }
-    }
 }

--- a/eventbus-android/build.gradle
+++ b/eventbus-android/build.gradle
@@ -5,22 +5,23 @@ buildscript {
     }
 
     dependencies {
-        // Note: IntelliJ IDEA 2021.1 only supports up to version 4.1
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:8.0.2'
     }
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'maven-publish'
 
 group = rootProject.group
 version = rootProject.version
 
 android {
-    compileSdkVersion _compileSdkVersion
+    namespace "org.greenrobot.eventbus.android"
+    compileSdkVersion = _compileSdkVersion
 
     defaultConfig {
         minSdkVersion 7
-        targetSdkVersion 30 // Android 11 (R)
+        targetSdkVersion 33 // Android 11 (R)
 
         consumerProguardFiles "consumer-rules.pro"
     }
@@ -28,34 +29,42 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    publishing {
+        singleVariant('release') {
+            withSourcesJar()
+        }
+    }
 }
 
 dependencies {
     api project(":eventbus-java")
 }
 
-task sourcesJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    archiveClassifier.set("sources")
-}
-
-apply from: rootProject.file("gradle/publish.gradle")
 // Set project-specific properties
 // https://developer.android.com/studio/build/maven-publish-plugin
 // Because the Android components are created only during the afterEvaluate phase, you must
 // configure your publications using the afterEvaluate() lifecycle method.
 afterEvaluate {
-    publishing.publications {
-        mavenJava(MavenPublication) {
-            artifactId = "eventbus"
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                artifactId = "eventbus"
 
-            from components.release
-            artifact sourcesJar
+                from components.release
 
-            pom {
-                name = "EventBus"
-                description = "EventBus is a publish/subscribe event bus optimized for Android."
-                packaging = "aar"
+                pom {
+                    name = "EventBus"
+                    description = "EventBus is a publish/subscribe event bus optimized for Android."
+                }
+            }
+        }
+
+        repositories {
+            maven {
+                name = "GitHubPackages"
+                url = project.uri("https://maven.pkg.github.com/favordelivery/EventBus")
+                credentials(PasswordCredentials)
             }
         }
     }

--- a/eventbus-android/src/main/AndroidManifest.xml
+++ b/eventbus-android/src/main/AndroidManifest.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.greenrobot.eventbus.android">
-
-</manifest>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Update EventBus infra so it can be compiled again

Updated java, gradle, AGP
Update build scripts to work with AGP
Removed ability to publish to maven central

### Do not fail when eventBusIndex is not present

EventBus annotation processor is conflicting with hilt annotation
processing which results in a broken incremental compilation.

Hilt runs annotation processing in a special gradle task that also
happens to execute other annotation processors when kapt task is
up-to-date. But hilt does not pass the original arguments to the
processors which eventbus expects to see.

This change changes behavior to not fail annotation processing but to
instead not run it.
This should be safe as:
 - we do have `eventBusIndex` configured in our projects and don't
 really need to eventbus to double-check this
 - the problem only occurs when EventBusAnnotationProcessor would not
 have been executed as kapt task is up-to-date and is only executed
 because hilt forces it to execute.